### PR TITLE
fix: add missing adbutils dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["httpx", "Pillow", "retry", "apkutils2"]
+dependencies = ["httpx", "Pillow", "retry", "apkutils2", "adbutils"]
 keywords = ["adb", "adbutils", "async", "android", "droidrun"]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ httpx
 retry
 apkutils2
 Pillow
+adbutils


### PR DESCRIPTION
Fixes #1

The `adbutils` module is used throughout the codebase (in pidcat.py and tests) but was not listed in dependencies, causing installation errors.

## Changes
- Added `adbutils` to dependencies in `pyproject.toml`
- Added `adbutils` to `requirements.txt`

Generated with [Claude Code](https://claude.ai/code)